### PR TITLE
fix: bump flatted to 3.4.1 (high-severity CVE)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3402,9 +3402,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },


### PR DESCRIPTION
## Summary
- Bumps flatted from 3.2.9 to 3.4.1 in ui/package-lock.json
- Fixes high-severity vulnerability: unbounded recursion DoS in parse() revive phase

## Test plan
- [ ] Verify UI builds correctly
- [ ] Confirm no breaking changes